### PR TITLE
Allow underscores in identifiers

### DIFF
--- a/src/Glob/Scanner.cs
+++ b/src/Glob/Scanner.cs
@@ -96,7 +96,7 @@ namespace Glob
                 return TakeIdentifier();
             }
 
-            if (IsNumeric(current))
+            if (IsNumeric(current) || current == '_')
             {
                 return TakeIdentifier();
             }
@@ -152,7 +152,8 @@ namespace Glob
 
         private TokenKind TakeIdentifier()
         {
-            while (IsAlphaNumeric((char)this._currentCharacter))
+            
+            while (IsIdentifierCharacter((char)this._currentCharacter))
             {
                 this.TakeIt();
             }
@@ -160,7 +161,7 @@ namespace Glob
             return TokenKind.Identifier;
         }
 
-        private static bool IsAlphaNumeric(char c) => char.IsLetter(c) || IsNumeric(c);
+        private static bool IsIdentifierCharacter(char c) => char.IsLetter(c) || IsNumeric(c) || c == '_';
 
         private static bool IsNumeric(char c) => char.IsDigit(c) || c == '.' || c == '-';
     }

--- a/test/Glob.Tests/GlobTests.cs
+++ b/test/Glob.Tests/GlobTests.cs
@@ -29,6 +29,15 @@ namespace Glob.Tests
         }
 
         [Fact]
+        public void CanMatchUnderscore()
+        {
+            var glob = new Glob("a_*file.txt");
+            Assert.True(glob.IsMatch("a_bigfile.txt"));
+            Assert.True(glob.IsMatch("a_file.txt"));
+            Assert.False(glob.IsMatch("another_file.txt"));
+        }
+
+        [Fact]
         public void CanMatchSingleFile()
         {
             var glob = new Glob("*file.txt");

--- a/test/Glob.Tests/ScannerTests.cs
+++ b/test/Glob.Tests/ScannerTests.cs
@@ -27,6 +27,15 @@ namespace Glob.Tests
         }
 
         [Fact]
+        public void CanParseFileNameWithUnderscore()
+        {
+            var scanner = new Scanner("_foo_bar.*");
+            AssertToken( TokenKind.Identifier, "_foo_bar.", scanner.Scan() );
+            AssertToken( TokenKind.Wildcard, "*", scanner.Scan() );
+            AssertToken( TokenKind.EOT, "", scanner.Scan() );
+        }
+
+        [Fact]
         public void ParseWindowsRoot()
         {
             var scanner = new Scanner(@"C:\*.txt");


### PR DESCRIPTION
This change includes underscores as allowable characters in identifiers. They are treated the same way as numbers - i.e. allowed in file/path strings, but not in drive names. 