### PR TITLE
Add PackageLicenseExpression

### DIFF
--- a/src/Glob/Glob.csproj
+++ b/src/Glob/Glob.csproj
@@ -10,6 +10,7 @@
     <Description>A C# Glob library for .NET and .NET Core.</Description>
     <PackageReleaseNotes>https://github.com/kthompson/glob/blob/main/ChangeLog.md</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/kthompson/glob/</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageLicense>
       The MIT License (MIT)
 


### PR DESCRIPTION
License expression is the preferred way (shows in NuGet.org and used in license validations).