### PR TITLE
Upgrade NUKE to version 8.0

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -30,27 +30,30 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Cache .nuke/temp, ~/.nuget/packages
+      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:
           path: |
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', '**/*.csproj') }}
-      - name: Run './build.cmd ReportCoverage Publish'
+      - name: 'Run: ReportCoverage, Publish'
         run: ./build.cmd ReportCoverage Publish
         env:
           PublicNuGetApiKey: ${{ secrets.PUBLIC_NUGET_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - name: 'Publish: test-results'
+        uses: actions/upload-artifact@v3
         with:
           name: test-results
           path: artifacts/test-results
-      - uses: actions/upload-artifact@v3
+      - name: 'Publish: coverage-report.zip'
+        uses: actions/upload-artifact@v3
         with:
           name: coverage-report.zip
           path: artifacts/reports/coverage-report.zip
-      - uses: actions/upload-artifact@v3
+      - name: 'Publish: packages'
+        uses: actions/upload-artifact@v3
         with:
           name: packages
           path: artifacts/packages

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,27 +29,30 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Cache .nuke/temp, ~/.nuget/packages
+      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:
           path: |
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', '**/*.csproj') }}
-      - name: Run './build.cmd Test ReportCoverage Pack'
+      - name: 'Run: Test, ReportCoverage, Pack'
         run: ./build.cmd Test ReportCoverage Pack
         env:
           CodecovToken: ${{ secrets.CODECOV_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - name: 'Publish: test-results'
+        uses: actions/upload-artifact@v3
         with:
           name: test-results
           path: artifacts/test-results
-      - uses: actions/upload-artifact@v3
+      - name: 'Publish: coverage-report.zip'
+        uses: actions/upload-artifact@v3
         with:
           name: coverage-report.zip
           path: artifacts/reports/coverage-report.zip
-      - uses: actions/upload-artifact@v3
+      - name: 'Publish: packages'
+        uses: actions/upload-artifact@v3
         with:
           name: packages
           path: artifacts/packages
@@ -60,27 +63,30 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Cache .nuke/temp, ~/.nuget/packages
+      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:
           path: |
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', '**/*.csproj') }}
-      - name: Run './build.cmd Test ReportCoverage Pack'
+      - name: 'Run: Test, ReportCoverage, Pack'
         run: ./build.cmd Test ReportCoverage Pack
         env:
           CodecovToken: ${{ secrets.CODECOV_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - name: 'Publish: test-results'
+        uses: actions/upload-artifact@v3
         with:
           name: test-results
           path: artifacts/test-results
-      - uses: actions/upload-artifact@v3
+      - name: 'Publish: coverage-report.zip'
+        uses: actions/upload-artifact@v3
         with:
           name: coverage-report.zip
           path: artifacts/reports/coverage-report.zip
-      - uses: actions/upload-artifact@v3
+      - name: 'Publish: packages'
+        uses: actions/upload-artifact@v3
         with:
           name: packages
           path: artifacts/packages
@@ -91,27 +97,30 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Cache .nuke/temp, ~/.nuget/packages
+      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:
           path: |
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', '**/*.csproj') }}
-      - name: Run './build.cmd Test ReportCoverage Pack'
+      - name: 'Run: Test, ReportCoverage, Pack'
         run: ./build.cmd Test ReportCoverage Pack
         env:
           CodecovToken: ${{ secrets.CODECOV_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - name: 'Publish: test-results'
+        uses: actions/upload-artifact@v3
         with:
           name: test-results
           path: artifacts/test-results
-      - uses: actions/upload-artifact@v3
+      - name: 'Publish: coverage-report.zip'
+        uses: actions/upload-artifact@v3
         with:
           name: coverage-report.zip
           path: artifacts/reports/coverage-report.zip
-      - uses: actions/upload-artifact@v3
+      - name: 'Publish: packages'
+        uses: actions/upload-artifact@v3
         with:
           name: packages
           path: artifacts/packages

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
   "$ref": "#/definitions/build",
+  "title": "Build Schema",
   "definitions": {
     "build": {
       "type": "object",
@@ -9,6 +9,13 @@
         "CodecovToken": {
           "type": "string",
           "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
+        "Configuration": {
+          "type": "string",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
         },
         "Continue": {
           "type": "boolean",

--- a/build.ps1
+++ b/build.ps1
@@ -18,11 +18,10 @@ $TempDirectory = "$PSScriptRoot\\.nuke\temp"
 
 $DotNetGlobalFile = "$PSScriptRoot\\global.json"
 $DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
-$DotNetChannel = "Current"
+$DotNetChannel = "STS"
 
-$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
-$env:DOTNET_MULTILEVEL_LOOKUP = 0
+$env:DOTNET_NOLOGO = 1
 
 ###########################################################################
 # EXECUTION
@@ -61,9 +60,15 @@ else {
         ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
     }
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
+    $env:PATH = "$DotNetDirectory;$env:PATH"
 }
 
 Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
+
+if (Test-Path env:NUKE_ENTERPRISE_TOKEN) {
+    & $env:DOTNET_EXE nuget remove source "nuke-enterprise" > $null
+    & $env:DOTNET_EXE nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password $env:NUKE_ENTERPRISE_TOKEN > $null
+}
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -14,11 +14,10 @@ TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
-DOTNET_CHANNEL="Current"
+DOTNET_CHANNEL="STS"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-export DOTNET_MULTILEVEL_LOOKUP=0
+export DOTNET_NOLOGO=1
 
 ###########################################################################
 # EXECUTION
@@ -54,9 +53,15 @@ else
         "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "$DOTNET_VERSION" --no-path
     fi
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
+    export PATH="$DOTNET_DIRECTORY:$PATH"
 fi
 
 echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+
+if [[ ! -z ${NUKE_ENTERPRISE_TOKEN+x} && "$NUKE_ENTERPRISE_TOKEN" != "" ]]; then
+    "$DOTNET_EXE" nuget remove source "nuke-enterprise" &>/dev/null || true
+    "$DOTNET_EXE" nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password "$NUKE_ENTERPRISE_TOKEN" --store-password-in-clear-text &>/dev/null || true
+fi
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -8,11 +8,8 @@ using Nuke.Common.ProjectModel;
 using Nuke.Common.Utilities.Collections;
 using Nuke.Common;
 using Nuke.Common.Tooling;
-using Nuke.Common.Tools.Codecov;
 using Nuke.Common.Tools.ReportGenerator;
 using Nuke.Components;
-using static Nuke.Common.IO.FileSystemTasks;
-using Config = Nuke.Components.Configuration;
 
 [GitHubActions(
     "pr",
@@ -60,7 +57,6 @@ class Build : NukeBuild,
     [CI] readonly GitHubActions GitHubActions;
 
     GitRepository GitRepository => From<IHazGitRepository>().GitRepository;
-    public Config Configuration => IsLocalBuild ? Config.Debug : Config.Release;
     AbsolutePath SourceDirectory => RootDirectory / "src";
     AbsolutePath TestsDirectory => RootDirectory / "test";
 
@@ -73,12 +69,12 @@ class Build : NukeBuild,
         .Before<IRestore>()
         .Executes(() =>
         {
-            SourceDirectory.GlobDirectories("**/bin", "**/obj").ForEach(DeleteDirectory);
-            TestsDirectory.GlobDirectories("**/bin", "**/obj").ForEach(DeleteDirectory);
-            EnsureCleanDirectory(From<IHazArtifacts>().ArtifactsDirectory);
+            SourceDirectory.GlobDirectories("**/bin", "**/obj").ForEach(x => x.DeleteDirectory());
+            TestsDirectory.GlobDirectories("**/bin", "**/obj").ForEach(x => x.DeleteDirectory());
+            From<IHazArtifacts>().ArtifactsDirectory.CreateOrCleanDirectory();
         });
 
-    public IEnumerable<Project> TestProjects => From<IHazSolution>().Solution.GetProjects("*.Tests");
+    public IEnumerable<Project> TestProjects => From<IHazSolution>().Solution.GetAllProjects("*.Tests");
 
     public bool CreateCoverageHtmlReport => true;
     public bool ReportToCodecov => false; // TODO: #74 RuntimeInformation.IsOSPlatform(OSPlatform.Windows);

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -15,14 +15,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Nuke.Common" Version="6.3.0" />
-    <PackageReference Include="Nuke.Components" Version="6.3.0" />
-    <PackageReference Include="Nuke.GitHub" Version="3.0.0" />
+    <PackageReference Include="Nuke.Common" Version="8.0.0" />
+    <PackageReference Include="Nuke.Components" Version="8.0.0" />
+    <PackageReference Include="Nuke.GitHub" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageDownload Include="Codecov.Tool" Version="[1.12.3]" />
-    <PackageDownload Include="nbgv" Version="[3.5.119]" />
+    <PackageDownload Include="nbgv" Version="[3.6.133]" />
     <PackageDownload Include="ReportGenerator" Version="[5.1.15]" />
   </ItemGroup>
 


### PR DESCRIPTION
Done this quite many times so trying to save you some time 🙂 The version on nuget.org is reporting as non-deterministic build so new NUKE version should fix that as it sets `ContinousIntegrationBuild` to `true`. Then only thing left is that it's missing symbols, but probably another issue/PR.