### PR TITLE
docs: update release docs and automate GitHub releases

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -37,8 +37,8 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', '**/*.csproj') }}
-      - name: 'Run: ReportCoverage, Publish'
-        run: ./build.cmd ReportCoverage Publish
+      - name: 'Run: ReportCoverage, Publish, CreateGitHubRelease'
+        run: ./build.cmd ReportCoverage Publish CreateGitHubRelease
         env:
           PublicNuGetApiKey: ${{ secrets.PUBLIC_NUGET_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Updated
 - Improved performance from parser internals rework
-- Updated to .NET 6.0
+- Updated to .NET 8.0
 
 ### Changed
 - Matching full path is now the default for Glob expressions, GlobOptions.MatchFilenameOnly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,7 @@ Please note we have a code of conduct, please follow it in all your interactions
    build.
 2. Update the README.md with details of changes to the interface, this includes new environment 
    variables, exposed ports, useful file locations and container parameters.
-3. Increase the version numbers in any examples files and the README.md to the new version that this
-   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+3. Version numbers are managed automatically by [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) — do not manually update version numbers. See [ReleaseSteps.md](ReleaseSteps.md) for how releases work. The versioning scheme follows [SemVer](http://semver.org/).
 4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
    do not have permission to do that, you may request the second reviewer to merge it for you.
 

--- a/ReleaseSteps.md
+++ b/ReleaseSteps.md
@@ -1,9 +1,48 @@
 # Release steps
 
-* Update changelog
-* Update changelog links
-* Update solution VersionPrefix
-* Update solution PackageReleaseNotes
-* Tag release
-* Add github release
-* Run azure release to nuget
+This project uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) for automatic versioning and publishes to NuGet via CI on every push to `main`. There is no manual tagging or version-bumping required for a normal release.
+
+## Normal release (patch/build increment)
+
+1. **Update `CHANGELOG.md`** — move items from `[Unreleased]` into a new versioned section. You won't know the exact version number until after the merge, but you can look it up from the CI build or use `nbgv get-version` locally beforehand.
+
+2. **Merge to `main`** — a fast-forward merge is preferred so the version that was tested on the source branch is identical to what gets published:
+
+   ```bash
+   git checkout main
+   git merge --ff-only develop
+   git push
+   ```
+
+   If a fast-forward is not possible, a regular merge commit is fine — it will just increment the version height by one.
+
+3. **CI publishes automatically** — the `continuous` workflow runs on push to `main`, builds the package, and pushes it to NuGet.org using the `PUBLIC_NUGET_API_KEY` secret. No manual action needed.
+
+4. **Create a GitHub release** (optional but recommended) — after the CI build completes, create a GitHub release tagged with the version number for visibility.
+
+## Bumping the major or minor version
+
+To release a new major or minor version (e.g., `2.1` or `3.0`), update `version.json` before merging:
+
+```json
+{
+  "version": "2.1-beta",
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$",
+    "^refs/heads/v\\d+(?:\\.\\d+)?$"
+  ]
+}
+```
+
+Commit this change on `develop` (or a feature branch), then follow the normal release steps above.
+
+## How versioning works
+
+| Branch | Version format | Example |
+|--------|---------------|---------|
+| `main` | `{major}.{minor}.{height}` | `2.0.42` |
+| `develop` | `{major}.{minor}.{height}-beta` | `2.0.42-beta` |
+| Feature branch | `{major}.{minor}.{height}-beta+{commitId}` | `2.0.42-beta+abc1234` |
+
+The **height** is the number of commits since `version.json` was last changed on that branch. Only `main` (and `v*` branches) produce public release versions — all other branches produce prerelease packages.
+

--- a/ReleaseSteps.md
+++ b/ReleaseSteps.md
@@ -4,7 +4,12 @@ This project uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.Gi
 
 ## Normal release (patch/build increment)
 
-1. **Update `CHANGELOG.md`** — move items from `[Unreleased]` into a new versioned section. You won't know the exact version number until after the merge, but you can look it up from the CI build or use `nbgv get-version` locally beforehand.
+1. **Update `CHANGELOG.md`** — move items from `[Unreleased]` into a new versioned section. You can check the upcoming version with:
+
+   ```bash
+   dotnet tool install -g nbgv
+   nbgv get-version -v NuGetPackageVersion
+   ```
 
 2. **Merge to `main`** — a fast-forward merge is preferred so the version that was tested on the source branch is identical to what gets published:
 
@@ -16,9 +21,11 @@ This project uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.Gi
 
    If a fast-forward is not possible, a regular merge commit is fine — it will just increment the version height by one.
 
-3. **CI publishes automatically** — the `continuous` workflow runs on push to `main`, builds the package, and pushes it to NuGet.org using the `PUBLIC_NUGET_API_KEY` secret. No manual action needed.
-
-4. **Create a GitHub release** (optional but recommended) — after the CI build completes, create a GitHub release tagged with the version number for visibility.
+3. **CI does the rest automatically** — the `continuous` workflow runs on push to `main` and:
+   - Builds and runs tests
+   - Publishes the NuGet package to nuget.org
+   - Creates a GitHub release tagged with the NBGV version (e.g., `v2.0.42`), using the first section of `CHANGELOG.md` as the release notes
+   - Attaches the `.nupkg` files as release assets
 
 ## Bumping the major or minor version
 

--- a/ReleaseSteps.md
+++ b/ReleaseSteps.md
@@ -45,11 +45,11 @@ Commit this change on `develop` (or a feature branch), then follow the normal re
 
 ## How versioning works
 
-| Branch | Version format | Example |
-|--------|---------------|---------|
-| `main` | `{major}.{minor}.{height}` | `2.0.42` |
-| `develop` | `{major}.{minor}.{height}-beta` | `2.0.42-beta` |
-| Feature branch | `{major}.{minor}.{height}-beta+{commitId}` | `2.0.42-beta+abc1234` |
+| Branch         | Version format                              | Example                  |
+|----------------|---------------------------------------------|--------------------------|
+| `main`         | `{major}.{minor}.{height}`                  | `2.0.42`                 |
+| `develop`      | `{major}.{minor}.{height}-beta`             | `2.0.42-beta`            |
+| Feature branch | `{major}.{minor}.{height}-beta+{commitId}`  | `2.0.42-beta+abc1234`    |
 
 The **height** is the number of commits since `version.json` was last changed on that branch. Only `main` (and `v*` branches) produce public release versions — all other branches produce prerelease packages.
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -29,7 +29,7 @@ using Nuke.Components;
     FetchDepth = 0,
     OnPushBranches = new[] { MainBranch, DevelopBranch },
     PublishArtifacts = true,
-    InvokedTargets = new[] { nameof(IReportCoverage.ReportCoverage), nameof(IPublish.Publish) },
+    InvokedTargets = new[] { nameof(IReportCoverage.ReportCoverage), nameof(IPublish.Publish), nameof(ICreateGitHubRelease.CreateGitHubRelease) },
     CacheKeyFiles = new[] { "global.json", "**/*.csproj" },
     ImportSecrets = new [] { nameof(PublicNuGetApiKey) },
     EnableGitHubToken = true)]
@@ -45,7 +45,8 @@ class Build : NukeBuild,
     IReportCoverage,
     IReportIssues,
     IReportDuplicates,
-    IPublish
+    IPublish,
+    ICreateGitHubRelease
 {
     /// Support plugins are available for:
     ///   - JetBrains ReSharper        https://nuke.build/resharper
@@ -102,6 +103,17 @@ class Build : NukeBuild,
             IsOriginalRepository && GitHubActions != null &&
             (GitRepository.IsOnMainBranch() || GitRepository.IsOnDevelopBranch()))
         .WhenSkipped(DependencyBehavior.Execute);
+
+    string ICreateGitHubRelease.Name => $"v{From<IHazNerdbankGitVersioning>().Versioning.NuGetPackageVersion}";
+
+    IEnumerable<AbsolutePath> ICreateGitHubRelease.AssetFiles =>
+        From<IPack>().PackagesDirectory.GlobFiles("*.nupkg");
+
+    Target ICreateGitHubRelease.CreateGitHubRelease => _ => _
+        .Inherit<ICreateGitHubRelease>()
+        .TriggeredBy(From<IPublish>().Publish)
+        .OnlyWhenStatic(() => IsOriginalRepository && GitRepository.IsOnMainBranch())
+        .WhenSkipped(DependencyBehavior.Skip);
 
     T From<T>()
         where T : INukeBuild


### PR DESCRIPTION
The release process documentation was completely out of date (referencing Azure pipelines, manual tagging, and manual version bumps), and there was no automation for creating GitHub releases. This PR fixes both.

## What changed

**`ReleaseSteps.md`** -- fully rewritten to reflect the current NBGV + GitHub Actions workflow:
- Documents the actual 3-step release process: update changelog, FF merge to `main`, CI does the rest
- Explains fast-forward vs merge-commit tradeoff and its effect on version numbers
- Documents how to bump major/minor version via `version.json`
- Includes a versioning table showing per-branch version formats

**`build/Build.cs`** -- added `ICreateGitHubRelease` to the build class:
- Release name is derived from the NBGV version (e.g. `v2.0.42`)
- Asset files are the built `.nupkg` artifacts
- Release is triggered automatically after `Publish` succeeds, and is skipped on `develop` (main branch only)
- Release notes body is pulled from the first section of `CHANGELOG.md`

**`.github/workflows/continuous.yml`** -- `CreateGitHubRelease` added to the continuous build run step.

**`CONTRIBUTING.md`** -- removed the stale instruction to manually bump version numbers; replaced with a pointer to `ReleaseSteps.md`.

**`CHANGELOG.md`** -- corrected `.NET 6.0` to `.NET 8.0` in the `[Unreleased]` section.