### PR TITLE
Fix GlobExtensionTests to work in git worktrees

### DIFF
--- a/test/Glob.Tests/GlobExtensionTests.cs
+++ b/test/Glob.Tests/GlobExtensionTests.cs
@@ -45,21 +45,21 @@ public class GlobExtensionTests
         }
 
     [Fact]
-    public void CanMatchInfoInFileSystemInfo()
+    public void CanMatchSrcInFileSystemInfo()
     {
             var root = new DirectoryInfo(SourceRoot);
-            var allInfoFilesAndFolders = root.GlobFileSystemInfos("**/*info");
+            var allSrcFilesAndFolders = root.GlobFileSystemInfos("**/*src");
 
-            Assert.True(allInfoFilesAndFolders.Any(), "There should be some 'allInfoFilesAndFolders'");
+            Assert.True(allSrcFilesAndFolders.Any(), "There should be some items named 'src'");
         }
 
     [Fact]
-    public void CanMatchInfoInFileSystemInfoCaseInsensitive()
+    public void CanMatchSrcInFileSystemInfoCaseInsensitive()
     {
             var root = new DirectoryInfo(SourceRoot);
-            var allInfoFilesAndFolders = root.GlobFileSystemInfos("**/*INFO", GlobOptions.CaseInsensitive);
+            var allSrcFilesAndFolders = root.GlobFileSystemInfos("**/*SRC", GlobOptions.CaseInsensitive);
 
-            Assert.True(allInfoFilesAndFolders.Any(), "There should be some 'allINFOFilesAndFolders'");
+            Assert.True(allSrcFilesAndFolders.Any(), "There should be some items named 'src'");
         }
 
     [Fact]


### PR DESCRIPTION
## Problem

`CanMatchInfoInFileSystemInfo` and `CanMatchInfoInFileSystemInfoCaseInsensitive` used the pattern `**/*info`, which relied on `.git/info/` being a directory. In a git worktree, `.git` is a file (not a directory), so `.git/info/` doesn't exist and the tests fail locally.

## Fix

Replace the `**/*info` / `**/*INFO` patterns with `**/*src` / `**/*SRC`, which match the `src/` directory that is always present in any checkout or worktree. Also renamed the tests and variables to match.